### PR TITLE
docs(README.md): update title link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h3 align="center">
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/logos/exports/1544x1544_circle.png" width="100" alt="Logo"/><br/>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
-	Catppuccin for <a href="https://github.com/tomszilagyi/zutty">Zutty</a>
+	Catppuccin for <a href="https://git.hq.sig7.se/zutty.git">Zutty</a>
 	<img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/misc/transparent.png" height="30" width="0px"/>
 </h3>
 


### PR DESCRIPTION
The original author has moved away from GitHub, this PR updates the title link to point towards the new location of the repository.